### PR TITLE
Remove redundant subdomains

### DIFF
--- a/mackeeper_blocker
+++ b/mackeeper_blocker
@@ -11,9 +11,6 @@ end
 
 #initiate domain list array
 mk_address_list = [
-  "mackeeperapp.mackeeper.com",
-  "mackeeperapp2.mackeeper.com",
-  "mackeeperapp3.mackeeper.com",
   "mackeeper.com"
 ]
 


### PR DESCRIPTION
The subdomains are not needed as the main domain is already blocked.
