### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Mackeeper Blocker
 Blocks mackeeper domain names by adding them into the hosts file
 
-#Usage
+# Usage
 
 Simply execute mackeeper_blocker in the terminal.app and it'll add the domain names to the hosts file in order to block them (the script will ask for root password to be able to write in hosts file)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
