### PR TITLE
Block more MacKeeper domains

### DIFF
--- a/mackeeper_blocker
+++ b/mackeeper_blocker
@@ -11,10 +11,14 @@ end
 
 #initiate domain list array
 mk_address_list = [
+  "cf.mackeeper.com",
+  "download.mackeeper.com",
   "mackeeperapp.mackeeper.com",
   "mackeeperapp2.mackeeper.com",
   "mackeeperapp3.mackeeper.com",
   "mackeeper.com",
+  "static.mackeeper.com",
+  "static-site.mackeeper.com",
   "trustedmaccleaner.com"
 ]
 


### PR DESCRIPTION
They like to shuffle their ad domains, so instead of directly blocking the domains, break their resources instead.

Fixes https://github.com/avatsaev/mackeeper_blocker/issues/9